### PR TITLE
Refactor error chain freeing to reduce code duplication

### DIFF
--- a/validator.c
+++ b/validator.c
@@ -32,9 +32,9 @@ json_schema_context *json_schema_context_create(int check_mode)
     return ctx;
 }
 
-void json_schema_context_free(json_schema_context *ctx)
+/* Helper to free a chain of error nodes */
+static void json_schema_free_error_chain(json_schema_error *error)
 {
-    json_schema_error *error = ctx->errors;
     while (error) {
         json_schema_error *next = error->next;
         if (error->message) zend_string_release(error->message);
@@ -43,6 +43,11 @@ void json_schema_context_free(json_schema_context *ctx)
         efree(error);
         error = next;
     }
+}
+
+void json_schema_context_free(json_schema_context *ctx)
+{
+    json_schema_free_error_chain(ctx->errors);
     if (ctx->current_path) {
         zend_string_release(ctx->current_path);
     }
@@ -73,17 +78,9 @@ void json_schema_context_truncate_errors(json_schema_context *ctx, int target_co
         return;
     }
 
-    if (target_count == 0) {
-        /* Free all errors */
-        json_schema_error *error = ctx->errors;
-        while (error) {
-            json_schema_error *next = error->next;
-            if (error->message) zend_string_release(error->message);
-            if (error->property) zend_string_release(error->property);
-            if (error->pointer) zend_string_release(error->pointer);
-            efree(error);
-            error = next;
-        }
+    /* Guard against negative target_count */
+    if (target_count <= 0) {
+        json_schema_free_error_chain(ctx->errors);
         ctx->errors = NULL;
         ctx->errors_tail = NULL;
         ctx->error_count = 0;
@@ -101,15 +98,7 @@ void json_schema_context_truncate_errors(json_schema_context *ctx, int target_co
         json_schema_error *to_free = current->next;
         current->next = NULL;
         ctx->errors_tail = current;
-
-        while (to_free) {
-            json_schema_error *next = to_free->next;
-            if (to_free->message) zend_string_release(to_free->message);
-            if (to_free->property) zend_string_release(to_free->property);
-            if (to_free->pointer) zend_string_release(to_free->pointer);
-            efree(to_free);
-            to_free = next;
-        }
+        json_schema_free_error_chain(to_free);
     }
 
     ctx->error_count = target_count;


### PR DESCRIPTION
## Summary
- Extract `json_schema_free_error_chain()` helper function to centralize error node freeing logic
- Use helper in `json_schema_context_free()` and `json_schema_context_truncate_errors()`
- Add guard against negative `target_count` in `truncate_errors()` to prevent inconsistent state

Address Sourcery review feedback from PR #4

## Summary by Sourcery

JSON スキーマ検証コンテキストのエラークリーンアップロジックをリファクタリングし、エラーノードの解放処理を集約して堅牢性を向上させました。

Enhancements:
- `json_schema_error` ノードのチェーンを解放する再利用可能なヘルパーを抽出し、コンテキストのクリーンアップ処理およびエラーの切り詰め処理の経路で使用することで、重複を削減しました。
- 非正のターゲット数に対するガードを追加することでエラー切り詰めロジックを厳密化し、コンテキストが不整合な状態のまま残らないようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor error cleanup logic for JSON schema validation context to centralize error node freeing and improve robustness.

Enhancements:
- Extract a reusable helper to free chains of json_schema_error nodes and use it in context cleanup and error truncation paths to reduce duplication.
- Tighten error truncation logic by guarding against non-positive target counts to avoid leaving the context in an inconsistent state.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization and consistency in error handling cleanup within the validator module. These changes enhance code maintainability and resource management without affecting end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->