### PR TITLE
Add package.xml for Pickle/PECL installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ tests/*.sh
 
 # Package files
 *.tgz
-package.xml
 
 # Composer
 vendor/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Akihito Koriyama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package packagerversion="1.10.15" version="2.0" xmlns="http://pear.php.net/dtd/package-2.0" xmlns:tasks="http://pear.php.net/dtd/tasks-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pear.php.net/dtd/tasks-1.0 http://pear.php.net/dtd/tasks-1.0.xsd http://pear.php.net/dtd/package-2.0 http://pear.php.net/dtd/package-2.0.xsd">
+ <name>json_schema</name>
+ <channel>pecl.php.net</channel>
+ <summary>High-performance JSON Schema validator</summary>
+ <description>A native C implementation of JSON Schema validator for PHP.
+Supports JSON Schema Draft-04/06/07 with 2178 tests passed from the official JSON Schema Test Suite.
+Provides both procedural and OOP APIs, with compatibility layer for jsonrainbow/json-schema.</description>
+ <lead>
+  <name>Akihito Koriyama</name>
+  <user>koriym</user>
+  <email>koriym@gmail.com</email>
+  <active>yes</active>
+ </lead>
+ <date>2026-01-06</date>
+ <time>12:00:00</time>
+ <version>
+  <release>1.0.0</release>
+  <api>1.0.0</api>
+ </version>
+ <stability>
+  <release>stable</release>
+  <api>stable</api>
+ </stability>
+ <license uri="https://opensource.org/licenses/MIT">MIT</license>
+ <notes>
+Initial stable release.
+- JSON Schema Draft-04/06/07 support
+- 2178 tests passed from JSON Schema Test Suite
+- Procedural API: json_schema_validate(), json_schema_get_errors()
+- OOP API: JsonSchema\Validator class
+- Compatibility layer for jsonrainbow/json-schema
+ </notes>
+ <contents>
+  <dir name="/">
+   <file name="config.m4" role="src" />
+   <file name="config.w32" role="src" />
+   <file name="json_schema.c" role="src" />
+   <file name="php_json_schema.h" role="src" />
+   <file name="validator.c" role="src" />
+   <file name="validator.h" role="src" />
+   <file name="LICENSE" role="doc" />
+   <file name="README.md" role="doc" />
+   <dir name="tests">
+    <file name="001-basic.phpt" role="test" />
+    <file name="002-type-validation.phpt" role="test" />
+    <file name="003-string-constraints.phpt" role="test" />
+    <file name="004-number-constraints.phpt" role="test" />
+    <file name="005-array-constraints.phpt" role="test" />
+    <file name="006-object-constraints.phpt" role="test" />
+    <file name="007-enum-const.phpt" role="test" />
+    <file name="008-combinators.phpt" role="test" />
+    <file name="009-format.phpt" role="test" />
+    <file name="010-ref.phpt" role="test" />
+    <file name="011-if-then-else.phpt" role="test" />
+    <file name="012-validator-class.phpt" role="test" />
+    <file name="013-constraint-constants.phpt" role="test" />
+    <file name="014-procedural-api.phpt" role="test" />
+    <file name="015-boolean-schema.phpt" role="test" />
+   </dir>
+  </dir>
+ </contents>
+ <dependencies>
+  <required>
+   <php>
+    <min>8.1.0</min>
+   </php>
+   <pearinstaller>
+    <min>1.10.0</min>
+   </pearinstaller>
+  </required>
+ </dependencies>
+ <providesextension>json_schema</providesextension>
+ <extsrcrelease />
+ <changelog>
+  <release>
+   <version>
+    <release>1.0.0</release>
+    <api>1.0.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2026-01-06</date>
+   <license uri="https://opensource.org/licenses/MIT">MIT</license>
+   <notes>
+Initial stable release.
+   </notes>
+  </release>
+ </changelog>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,9 @@ Initial stable release.
 - 2178 tests passed from JSON Schema Test Suite
 - Procedural API: json_schema_validate(), json_schema_get_errors()
 - OOP API: JsonSchema\Validator class
-- Compatibility layer for jsonrainbow/json-schema
+
+Note: PHP compatibility layer for jsonrainbow/json-schema is available
+separately via Composer (see https://github.com/koriym/ext-json-schema)
  </notes>
  <contents>
   <dir name="/">


### PR DESCRIPTION
## Summary

- Add `package.xml` with proper metadata for PECL packaging
- Add MIT `LICENSE` file
- Update `.gitignore` to track `package.xml`

## Installation via Pickle

Users can now install the extension using Pickle:

```bash
pickle install https://github.com/koriym/ext-json-schema
```

This provides an easier installation method without requiring PECL repository registration.

## Summary by Sourcery

json_schema拡張機能を Pickle などのツールで配布できるようにするため、PECL/PEAR 向けのパッケージング用メタデータとライセンスファイルを追加します。

New Features:
- PEAR 互換ツール経由でのインストールをサポートするため、json_schema 拡張機能、その内容および依存関係を記述した、PECL 互換の `package.xml` を導入します。

Enhancements:
- トップレベルの `LICENSE` ファイルにより、この拡張機能が MIT ライセンスであることを文書化します。
- `package.xml` のようなパッケージングメタデータファイルがバージョン管理で追跡されるようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add PECL/PEAR packaging metadata and licensing files to enable distribution of the json_schema extension via tools like Pickle.

New Features:
- Introduce a PECL-compatible package.xml describing the json_schema extension, its contents, and dependencies to support installation via PEAR-compatible tools.

Enhancements:
- Document the extension as MIT-licensed via a top-level LICENSE file.
- Ensure packaging metadata files such as package.xml are tracked in version control.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an MIT License to clarify project licensing and permissions.
  * Updated ignore rules so the package manifest will now be tracked by version control.
  * Added a package manifest describing the json_schema extension (metadata, contents, dependencies, and initial stable release).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->