### PR TITLE
Add external $ref resolution with PHP callback

### DIFF
--- a/json_schema.c
+++ b/json_schema.c
@@ -30,6 +30,8 @@ static zend_object_handlers json_schema_validator_handlers;
 typedef struct _json_schema_validator_object {
     int check_mode;
     zval errors;        /* Array of error objects */
+    zval ref_resolver;  /* PHP callback for external $ref resolution */
+    zend_string *base_uri; /* Base URI for relative $ref resolution */
     zend_object std;
 } json_schema_validator_object;
 
@@ -49,6 +51,8 @@ static zend_object *json_schema_validator_create_object(zend_class_entry *ce)
 
     intern->check_mode = JSON_SCHEMA_CHECK_MODE_NORMAL;
     array_init(&intern->errors);
+    ZVAL_UNDEF(&intern->ref_resolver);
+    intern->base_uri = NULL;
 
     zend_object_std_init(&intern->std, ce);
     object_properties_init(&intern->std, ce);
@@ -63,6 +67,12 @@ static void json_schema_validator_free_object(zend_object *obj)
     json_schema_validator_object *intern = json_schema_validator_from_obj(obj);
 
     zval_ptr_dtor(&intern->errors);
+    if (Z_TYPE(intern->ref_resolver) != IS_UNDEF) {
+        zval_ptr_dtor(&intern->ref_resolver);
+    }
+    if (intern->base_uri) {
+        zend_string_release(intern->base_uri);
+    }
     zend_object_std_dtor(&intern->std);
 }
 
@@ -210,6 +220,14 @@ PHP_METHOD(JsonSchema_Validator, validate)
     /* Create validation context */
     json_schema_context *ctx = json_schema_context_create((int)check_mode);
 
+    /* Set external ref resolver if configured */
+    if (Z_TYPE(intern->ref_resolver) != IS_UNDEF) {
+        json_schema_context_set_resolver(ctx, &intern->ref_resolver);
+    }
+    if (intern->base_uri) {
+        json_schema_context_set_base_uri(ctx, intern->base_uri);
+    }
+
     /* Perform validation */
     int result = json_schema_validate(data, schema, ctx);
 
@@ -292,6 +310,60 @@ PHP_METHOD(JsonSchema_Validator, setCheckMode)
 
     json_schema_validator_object *intern = Z_JSON_SCHEMA_VALIDATOR_P(ZEND_THIS);
     intern->check_mode = (int)check_mode;
+}
+/* }}} */
+
+/* {{{ proto void JsonSchema\Validator::setRefResolver(?callable $resolver)
+   Sets the external $ref resolver callback */
+PHP_METHOD(JsonSchema_Validator, setRefResolver)
+{
+    zval *resolver = NULL;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_ZVAL(resolver)
+    ZEND_PARSE_PARAMETERS_END();
+
+    json_schema_validator_object *intern = Z_JSON_SCHEMA_VALIDATOR_P(ZEND_THIS);
+
+    /* Release old resolver if set */
+    if (Z_TYPE(intern->ref_resolver) != IS_UNDEF) {
+        zval_ptr_dtor(&intern->ref_resolver);
+        ZVAL_UNDEF(&intern->ref_resolver);
+    }
+
+    /* Set new resolver if callable */
+    if (resolver && Z_TYPE_P(resolver) != IS_NULL) {
+        if (!zend_is_callable(resolver, 0, NULL)) {
+            zend_throw_exception(zend_ce_type_error, "Resolver must be callable or null", 0);
+            return;
+        }
+        ZVAL_COPY(&intern->ref_resolver, resolver);
+    }
+}
+/* }}} */
+
+/* {{{ proto void JsonSchema\Validator::setBaseUri(?string $baseUri)
+   Sets the base URI for relative $ref resolution */
+PHP_METHOD(JsonSchema_Validator, setBaseUri)
+{
+    zend_string *base_uri = NULL;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STR_OR_NULL(base_uri)
+    ZEND_PARSE_PARAMETERS_END();
+
+    json_schema_validator_object *intern = Z_JSON_SCHEMA_VALIDATOR_P(ZEND_THIS);
+
+    /* Release old base_uri if set */
+    if (intern->base_uri) {
+        zend_string_release(intern->base_uri);
+        intern->base_uri = NULL;
+    }
+
+    /* Set new base_uri */
+    if (base_uri) {
+        intern->base_uri = zend_string_copy(base_uri);
+    }
 }
 /* }}} */
 
@@ -407,6 +479,14 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_schema_validator_set_check_
     ZEND_ARG_TYPE_INFO(0, checkMode, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_schema_validator_set_ref_resolver, 0, 1, IS_VOID, 0)
+    ZEND_ARG_TYPE_INFO(0, resolver, IS_CALLABLE, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_schema_validator_set_base_uri, 0, 1, IS_VOID, 0)
+    ZEND_ARG_TYPE_INFO(0, baseUri, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
 /* Procedural API argument info */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_json_schema_validate, 0, 2, _IS_BOOL, 0)
     ZEND_ARG_TYPE_INFO(0, data, IS_MIXED, 0)
@@ -438,6 +518,8 @@ static const zend_function_entry json_schema_validator_methods[] = {
     PHP_ME(JsonSchema_Validator, reset, arginfo_json_schema_validator_reset, ZEND_ACC_PUBLIC)
     PHP_ME(JsonSchema_Validator, getCheckMode, arginfo_json_schema_validator_get_check_mode, ZEND_ACC_PUBLIC)
     PHP_ME(JsonSchema_Validator, setCheckMode, arginfo_json_schema_validator_set_check_mode, ZEND_ACC_PUBLIC)
+    PHP_ME(JsonSchema_Validator, setRefResolver, arginfo_json_schema_validator_set_ref_resolver, ZEND_ACC_PUBLIC)
+    PHP_ME(JsonSchema_Validator, setBaseUri, arginfo_json_schema_validator_set_base_uri, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 

--- a/tests/016-external-ref.phpt
+++ b/tests/016-external-ref.phpt
@@ -1,0 +1,119 @@
+--TEST--
+External $ref resolution with PHP callback
+--EXTENSIONS--
+json_schema
+--FILE--
+<?php
+
+// Simulated external schemas
+$externalSchemas = [
+    'types.json' => [
+        'definitions' => [
+            'positiveInteger' => [
+                'type' => 'integer',
+                'minimum' => 1
+            ],
+            'email' => [
+                'type' => 'string',
+                'format' => 'email'
+            ]
+        ]
+    ],
+    'user.json' => [
+        'type' => 'object',
+        'properties' => [
+            'name' => ['type' => 'string'],
+            'age' => ['$ref' => 'types.json#/definitions/positiveInteger']
+        ],
+        'required' => ['name', 'age']
+    ]
+];
+
+$validator = new JsonSchema\Validator();
+
+// Set up resolver callback
+$validator->setRefResolver(function(string $uri, string $baseUri) use ($externalSchemas) {
+    // Simple resolution - just look up in our array
+    if (isset($externalSchemas[$uri])) {
+        return $externalSchemas[$uri];
+    }
+    return null;
+});
+
+// Test 1: Direct external reference
+echo "Test 1: External \$ref to user.json\n";
+$schema = ['$ref' => 'user.json'];
+$data = ['name' => 'John', 'age' => 30];
+$result = $validator->validate($data, $schema);
+echo "Valid user: " . ($result ? "PASS" : "FAIL") . "\n";
+
+// Test 2: Invalid data against external schema
+echo "\nTest 2: Invalid data (negative age)\n";
+$data = ['name' => 'John', 'age' => -5];
+$result = $validator->validate($data, $schema);
+echo "Invalid age rejected: " . (!$result ? "PASS" : "FAIL") . "\n";
+$errors = $validator->getErrors();
+if (!empty($errors)) {
+    echo "Error: " . $errors[0]['message'] . "\n";
+}
+
+// Test 3: External reference with fragment
+echo "\nTest 3: External \$ref with fragment\n";
+$schema = [
+    'type' => 'object',
+    'properties' => [
+        'count' => ['$ref' => 'types.json#/definitions/positiveInteger']
+    ]
+];
+$data = ['count' => 5];
+$result = $validator->validate($data, $schema);
+echo "Valid count: " . ($result ? "PASS" : "FAIL") . "\n";
+
+$data = ['count' => 0];
+$result = $validator->validate($data, $schema);
+echo "Zero count rejected: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+// Test 4: Without resolver, external refs should fail
+echo "\nTest 4: Without resolver\n";
+$validator2 = new JsonSchema\Validator();
+$schema = ['$ref' => 'user.json'];
+$data = ['name' => 'John', 'age' => 30];
+$result = $validator2->validate($data, $schema);
+echo "No resolver returns error: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+// Test 5: setBaseUri
+echo "\nTest 5: Base URI\n";
+$validator->setBaseUri('/schemas/v1/');
+$validator->setRefResolver(function(string $uri, string $baseUri) use ($externalSchemas) {
+    echo "Resolver called with baseUri: $baseUri\n";
+    if (isset($externalSchemas[$uri])) {
+        return $externalSchemas[$uri];
+    }
+    return null;
+});
+$schema = ['$ref' => 'user.json'];
+$data = ['name' => 'Test', 'age' => 1];
+$validator->validate($data, $schema);
+
+echo "\nAll tests completed!\n";
+?>
+--EXPECT--
+Test 1: External $ref to user.json
+Valid user: PASS
+
+Test 2: Invalid data (negative age)
+Invalid age rejected: PASS
+Error: Value -5 is less than minimum 1
+
+Test 3: External $ref with fragment
+Valid count: PASS
+Zero count rejected: PASS
+
+Test 4: Without resolver
+No resolver returns error: PASS
+
+Test 5: Base URI
+Resolver called with baseUri: /schemas/v1/
+Resolver called with baseUri: /schemas/v1/
+
+All tests completed!

--- a/validator.c
+++ b/validator.c
@@ -50,6 +50,11 @@ json_schema_context *json_schema_context_create(int check_mode)
     ctx->ref_stack = emalloc(ctx->ref_stack_capacity * sizeof(zend_string *));
     ctx->ref_stack_depth = 0;
 
+    /* External $ref resolution */
+    ZVAL_UNDEF(&ctx->ref_resolver);
+    ctx->base_uri = NULL;
+    ctx->resolved_schemas = NULL;
+
     return ctx;
 }
 
@@ -83,6 +88,18 @@ void json_schema_context_free(json_schema_context *ctx)
         zend_string_release(ctx->ref_stack[i]);
     }
     efree(ctx->ref_stack);
+
+    /* Free external ref resolver resources */
+    if (Z_TYPE(ctx->ref_resolver) != IS_UNDEF) {
+        zval_ptr_dtor(&ctx->ref_resolver);
+    }
+    if (ctx->base_uri) {
+        zend_string_release(ctx->base_uri);
+    }
+    if (ctx->resolved_schemas) {
+        zend_hash_destroy(ctx->resolved_schemas);
+        FREE_HASHTABLE(ctx->resolved_schemas);
+    }
 
     efree(ctx);
 }
@@ -231,6 +248,31 @@ void json_schema_context_pop_path(json_schema_context *ctx)
             efree(ctx->path_segments[ctx->path_depth].segment);
             ctx->path_segments[ctx->path_depth].segment = NULL;
         }
+    }
+}
+
+/* External $ref resolver management */
+void json_schema_context_set_resolver(json_schema_context *ctx, zval *resolver)
+{
+    if (Z_TYPE(ctx->ref_resolver) != IS_UNDEF) {
+        zval_ptr_dtor(&ctx->ref_resolver);
+    }
+    if (resolver && Z_TYPE_P(resolver) != IS_NULL) {
+        ZVAL_COPY(&ctx->ref_resolver, resolver);
+    } else {
+        ZVAL_UNDEF(&ctx->ref_resolver);
+    }
+}
+
+void json_schema_context_set_base_uri(json_schema_context *ctx, zend_string *base_uri)
+{
+    if (ctx->base_uri) {
+        zend_string_release(ctx->base_uri);
+    }
+    if (base_uri) {
+        ctx->base_uri = zend_string_copy(base_uri);
+    } else {
+        ctx->base_uri = NULL;
     }
 }
 
@@ -1511,8 +1553,141 @@ zval *json_schema_resolve_ref(zend_string *ref, json_schema_context *ctx)
         return current;
     }
 
-    /* External references not supported in this implementation */
-    return NULL;
+    /* External reference - use PHP callback resolver */
+    if (Z_TYPE(ctx->ref_resolver) == IS_UNDEF) {
+        return NULL; /* No resolver configured */
+    }
+
+    /* Split URI and fragment: "other.json#/definitions/Foo" -> uri="other.json", fragment="/definitions/Foo" */
+    const char *fragment = strchr(ref_str, '#');
+    zend_string *uri;
+    if (fragment) {
+        uri = zend_string_init(ref_str, fragment - ref_str, 0);
+    } else {
+        uri = zend_string_copy(ref);
+    }
+
+    /* Check cache first */
+    zval *cached = NULL;
+    if (ctx->resolved_schemas) {
+        cached = zend_hash_find(ctx->resolved_schemas, uri);
+    }
+
+    zval *external_schema = NULL;
+    if (cached) {
+        external_schema = cached;
+    } else {
+        /* Call PHP resolver: resolver(uri, base_uri) */
+        zval retval;
+        zval params[2];
+        ZVAL_STR(&params[0], uri);
+        if (ctx->base_uri) {
+            ZVAL_STR(&params[1], ctx->base_uri);
+        } else {
+            ZVAL_EMPTY_STRING(&params[1]);
+        }
+
+        zend_fcall_info fci;
+        zend_fcall_info_cache fcc;
+        if (zend_fcall_info_init(&ctx->ref_resolver, 0, &fci, &fcc, NULL, NULL) == SUCCESS) {
+            fci.param_count = 2;
+            fci.params = params;
+            fci.retval = &retval;
+
+            if (zend_call_function(&fci, &fcc) == SUCCESS) {
+                if (Z_TYPE(retval) == IS_ARRAY) {
+                    /* Cache the resolved schema */
+                    if (!ctx->resolved_schemas) {
+                        ALLOC_HASHTABLE(ctx->resolved_schemas);
+                        zend_hash_init(ctx->resolved_schemas, 8, NULL, ZVAL_PTR_DTOR, 0);
+                    }
+                    zend_hash_add(ctx->resolved_schemas, uri, &retval);
+                    external_schema = zend_hash_find(ctx->resolved_schemas, uri);
+                } else {
+                    zval_ptr_dtor(&retval);
+                }
+            }
+        }
+    }
+
+    zend_string_release(uri);
+
+    if (!external_schema) {
+        return NULL;
+    }
+
+    /* If there's a fragment, resolve it within the external schema */
+    if (fragment && fragment[0] == '#') {
+        if (fragment[1] == '\0') {
+            return external_schema;
+        }
+        if (fragment[1] != '/') {
+            return NULL;
+        }
+
+        /* Parse JSON Pointer within external schema */
+        zval *current = external_schema;
+        const char *ptr = fragment + 2;
+
+        while (*ptr) {
+            const char *slash = strchr(ptr, '/');
+            size_t segment_len = slash ? (size_t)(slash - ptr) : strlen(ptr);
+
+            char segment[256];
+            if (segment_len >= sizeof(segment)) {
+                return NULL;
+            }
+            strncpy(segment, ptr, segment_len);
+            segment[segment_len] = '\0';
+
+            /* Decode JSON Pointer escapes */
+            char *src = segment;
+            char *dst = segment;
+            while (*src) {
+                if (*src == '~') {
+                    if (src[1] == '0') {
+                        *dst++ = '~';
+                        src += 2;
+                    } else if (src[1] == '1') {
+                        *dst++ = '/';
+                        src += 2;
+                    } else {
+                        *dst++ = *src++;
+                    }
+                } else {
+                    *dst++ = *src++;
+                }
+            }
+            *dst = '\0';
+
+            if (Z_TYPE_P(current) == IS_ARRAY) {
+                zval *next = zend_hash_str_find(Z_ARRVAL_P(current), segment, strlen(segment));
+                if (!next) {
+                    char *end;
+                    zend_long idx = strtol(segment, &end, 10);
+                    if (*end == '\0') {
+                        next = zend_hash_index_find(Z_ARRVAL_P(current), idx);
+                    }
+                }
+                if (!next) {
+                    return NULL;
+                }
+                current = next;
+            } else {
+                return NULL;
+            }
+
+            if (slash) {
+                ptr = slash + 1;
+            } else {
+                break;
+            }
+        }
+
+        return current;
+    }
+
+    return external_schema;
 }
 
 int json_schema_validate_ref(zval *data, zend_string *ref, json_schema_context *ctx)

--- a/validator.c
+++ b/validator.c
@@ -1580,9 +1580,9 @@ zval *json_schema_resolve_ref(zend_string *ref, json_schema_context *ctx)
         /* Call PHP resolver: resolver(uri, base_uri) */
         zval retval;
         zval params[2];
-        ZVAL_STR(&params[0], uri);
+        ZVAL_STR_COPY(&params[0], uri);
         if (ctx->base_uri) {
-            ZVAL_STR(&params[1], ctx->base_uri);
+            ZVAL_STR_COPY(&params[1], ctx->base_uri);
         } else {
             ZVAL_EMPTY_STRING(&params[1]);
         }
@@ -1608,6 +1608,10 @@ zval *json_schema_resolve_ref(zend_string *ref, json_schema_context *ctx)
                 }
             }
         }
+
+        /* Clean up params */
+        zval_ptr_dtor(&params[0]);
+        zval_ptr_dtor(&params[1]);
     }
 
     zend_string_release(uri);

--- a/validator.h
+++ b/validator.h
@@ -59,6 +59,11 @@ typedef struct _json_schema_context {
     zend_string **ref_stack;             /* Stack of $ref URIs being resolved */
     int ref_stack_depth;                 /* Current $ref stack depth */
     int ref_stack_capacity;              /* Allocated capacity */
+
+    /* External $ref resolution */
+    zval ref_resolver;                   /* PHP callback for external refs */
+    zend_string *base_uri;               /* Base URI for relative refs */
+    HashTable *resolved_schemas;         /* Cache of resolved external schemas */
 } json_schema_context;
 
 /* ============================================================================
@@ -129,6 +134,10 @@ void json_schema_context_truncate_errors(json_schema_context *ctx, int target_co
 void json_schema_context_push_path(json_schema_context *ctx, const char *segment);
 void json_schema_context_push_path_index(json_schema_context *ctx, zend_long index);
 void json_schema_context_pop_path(json_schema_context *ctx);
+
+/* External $ref resolver */
+void json_schema_context_set_resolver(json_schema_context *ctx, zval *resolver);
+void json_schema_context_set_base_uri(json_schema_context *ctx, zend_string *base_uri);
 
 /* ============================================================================
  * Utility functions


### PR DESCRIPTION
## Summary

Adds support for external `$ref` resolution via PHP callback, enabling references to external schema files.

### New Methods

- `Validator::setRefResolver(?callable $resolver)` - Set callback to resolve external refs
- `Validator::setBaseUri(?string $baseUri)` - Set base URI for relative ref resolution

### Usage

```php
$validator = new JsonSchema\Validator();

$validator->setRefResolver(function(string $uri, string $baseUri): ?array {
    // Resolve relative paths
    if (str_starts_with($uri, './')) {
        $path = dirname($baseUri) . '/' . $uri;
        return json_decode(file_get_contents($path), true);
    }
    // Resolve HTTP URLs
    if (str_starts_with($uri, 'http')) {
        return json_decode(file_get_contents($uri), true);
    }
    return null;
});

$validator->setBaseUri('/path/to/schemas/');
$validator->validate($data, $schema);
```

### Features

- PHP callback handles all external resolution (file, HTTP, custom protocols)
- Resolved schemas are cached per validation context
- Supports fragments: `other.json#/definitions/Foo`
- Base URI passed to resolver for relative path resolution

## Test plan

- [x] All 16 PHPT tests pass (including new 016-external-ref.phpt)
- [x] All 2178 JSON Schema Test Suite tests pass

## Summary by Sourcery

ユーザーが提供する PHP コールバックと任意のベース URI 設定、および検証ごとのキャッシュを用いて、外部 JSON Schema の `$ref` URI 解決をサポートします。

新機能:
- 外部 `$ref` URI を解決するための設定可能な PHP コールバックを `JsonSchema\Validator` に導入。
- 相対パスの `$ref` を解決するために、`JsonSchema\Validator` に任意指定のベース URI 設定を追加。
- `$ref` の追跡時に、外部から解決されたスキーマ内の JSON Pointer フラグメントに対応。

テスト:
- 外部 `$ref` の解決、フラグメントの扱い、リゾルバが存在しない場合、およびベース URI の伝播を対象とした PHPT カバレッジを追加。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for resolving external JSON Schema $ref URIs via a user-provided PHP callback with optional base URI configuration and per-validation caching.

New Features:
- Introduce configurable PHP callback on JsonSchema\Validator to resolve external $ref URIs.
- Add optional base URI configuration on JsonSchema\Validator for resolving relative $ref paths.
- Support JSON Pointer fragments within externally resolved schemas when following $ref values.

Tests:
- Add PHPT coverage for external $ref resolution, fragment handling, absence of resolver, and base URI propagation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure a callback to resolve external JSON Schema $ref values.
  * Set a base URI to support relative external $ref resolution.
  * Caching of resolved external schemas for better performance.

* **Tests**
  * Added end-to-end tests exercising external $ref resolution, fragment handling, base-URI behavior, and resolver absence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->