### PR TITLE
Refactor JSON Pointer resolution and add resolver edge case tests

### DIFF
--- a/tests/016-external-ref.phpt
+++ b/tests/016-external-ref.phpt
@@ -5,7 +5,7 @@ json_schema
 --FILE--
 <?php
 
-// Simulated external schemas
+// Simulated external schemas (including relative paths)
 $externalSchemas = [
     'types.json' => [
         'definitions' => [
@@ -26,6 +26,23 @@ $externalSchemas = [
             'age' => ['$ref' => 'types.json#/definitions/positiveInteger']
         ],
         'required' => ['name', 'age']
+    ],
+    // Relative path schemas
+    '/schemas/v1/common/string-types.json' => [
+        'definitions' => [
+            'nonEmptyString' => [
+                'type' => 'string',
+                'minLength' => 1
+            ]
+        ]
+    ],
+    '/schemas/v1/models/product.json' => [
+        'type' => 'object',
+        'properties' => [
+            'name' => ['$ref' => '../common/string-types.json#/definitions/nonEmptyString'],
+            'price' => ['type' => 'number', 'minimum' => 0]
+        ],
+        'required' => ['name', 'price']
     ]
 ];
 
@@ -95,6 +112,45 @@ $schema = ['$ref' => 'user.json'];
 $data = ['name' => 'Test', 'age' => 1];
 $validator->validate($data, $schema);
 
+// Test 6: Relative path resolution (./foo.json, ../bar.json)
+echo "\nTest 6: Relative path resolution\n";
+$validator3 = new JsonSchema\Validator();
+$validator3->setBaseUri('/schemas/v1/models/');
+$validator3->setRefResolver(function(string $uri, string $baseUri) use ($externalSchemas) {
+    // Resolve relative paths
+    if (str_starts_with($uri, './') || str_starts_with($uri, '../')) {
+        // Simple path resolution: combine baseUri with relative path
+        $basePath = rtrim($baseUri, '/');
+        $parts = explode('/', $basePath);
+
+        $relParts = explode('/', $uri);
+        foreach ($relParts as $part) {
+            if ($part === '..') {
+                array_pop($parts);
+            } elseif ($part !== '.' && $part !== '') {
+                $parts[] = $part;
+            }
+        }
+        $resolved = implode('/', $parts);
+        echo "Resolved: $uri -> $resolved\n";
+        return $externalSchemas[$resolved] ?? null;
+    }
+
+    // Absolute path
+    return $externalSchemas[$uri] ?? null;
+});
+
+// Test with schema that uses relative $ref internally
+$schema = ['$ref' => '/schemas/v1/models/product.json'];
+$data = ['name' => 'Widget', 'price' => 9.99];
+$result = $validator3->validate($data, $schema);
+echo "Valid product: " . ($result ? "PASS" : "FAIL") . "\n";
+
+// Test invalid data (empty name violates minLength: 1)
+$data = ['name' => '', 'price' => 9.99];
+$result = $validator3->validate($data, $schema);
+echo "Empty name rejected: " . (!$result ? "PASS" : "FAIL") . "\n";
+
 echo "\nAll tests completed!\n";
 ?>
 --EXPECT--
@@ -115,5 +171,11 @@ No resolver returns error: PASS
 Test 5: Base URI
 Resolver called with baseUri: /schemas/v1/
 Resolver called with baseUri: /schemas/v1/
+
+Test 6: Relative path resolution
+Resolved: ../common/string-types.json -> /schemas/v1/common/string-types.json
+Valid product: PASS
+Resolved: ../common/string-types.json -> /schemas/v1/common/string-types.json
+Empty name rejected: PASS
 
 All tests completed!

--- a/tests/017-resolver-edge-cases.phpt
+++ b/tests/017-resolver-edge-cases.phpt
@@ -1,0 +1,111 @@
+--TEST--
+External $ref resolver edge cases
+--EXTENSIONS--
+json_schema
+--FILE--
+<?php
+
+$validator = new JsonSchema\Validator();
+
+// Test 1: Resolver returning null
+echo "Test 1: Resolver returning null\n";
+$validator->setRefResolver(function(string $uri, string $baseUri) {
+    return null;
+});
+$schema = ['$ref' => 'nonexistent.json'];
+$data = ['foo' => 'bar'];
+$result = $validator->validate($data, $schema);
+echo "Null resolver result handled: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+// Test 2: Resolver returning invalid non-array value (string)
+echo "\nTest 2: Resolver returning string\n";
+$validator->setRefResolver(function(string $uri, string $baseUri) {
+    return "invalid string";
+});
+$result = $validator->validate($data, $schema);
+echo "String return handled: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+// Test 3: Resolver returning invalid non-array value (integer)
+echo "\nTest 3: Resolver returning integer\n";
+$validator->setRefResolver(function(string $uri, string $baseUri) {
+    return 42;
+});
+$result = $validator->validate($data, $schema);
+echo "Integer return handled: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+// Test 4: Resolver returning invalid non-array value (boolean)
+echo "\nTest 4: Resolver returning boolean\n";
+$validator->setRefResolver(function(string $uri, string $baseUri) {
+    return true;
+});
+$result = $validator->validate($data, $schema);
+echo "Boolean return handled: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+// Test 5: Resolver throwing exception
+echo "\nTest 5: Resolver throwing exception\n";
+$validator->setRefResolver(function(string $uri, string $baseUri) {
+    throw new RuntimeException("Resolver error");
+});
+try {
+    $result = $validator->validate($data, $schema);
+    echo "Exception handled: " . (!$result ? "PASS" : "FAIL") . "\n";
+} catch (Throwable $e) {
+    echo "Exception propagated: " . $e->getMessage() . "\n";
+}
+
+// Test 6: Circular external refs (A -> B -> A)
+echo "\nTest 6: Circular external refs\n";
+$circularSchemas = [
+    'schema-a.json' => [
+        'type' => 'object',
+        'properties' => [
+            'b' => ['$ref' => 'schema-b.json']
+        ]
+    ],
+    'schema-b.json' => [
+        'type' => 'object',
+        'properties' => [
+            'a' => ['$ref' => 'schema-a.json']
+        ]
+    ]
+];
+$validator->setRefResolver(function(string $uri, string $baseUri) use ($circularSchemas) {
+    return $circularSchemas[$uri] ?? null;
+});
+$schema = ['$ref' => 'schema-a.json'];
+$data = ['b' => ['a' => ['b' => []]]];
+$result = $validator->validate($data, $schema);
+echo "Circular refs handled: PASS\n";
+
+// Test 7: Clear resolver with null
+echo "\nTest 7: Clear resolver with null\n";
+$validator->setRefResolver(null);
+$schema = ['$ref' => 'external.json'];
+$result = $validator->validate($data, $schema);
+echo "Cleared resolver handled: " . (!$result ? "PASS" : "FAIL") . "\n";
+
+echo "\nAll edge case tests completed!\n";
+?>
+--EXPECT--
+Test 1: Resolver returning null
+Null resolver result handled: PASS
+
+Test 2: Resolver returning string
+String return handled: PASS
+
+Test 3: Resolver returning integer
+Integer return handled: PASS
+
+Test 4: Resolver returning boolean
+Boolean return handled: PASS
+
+Test 5: Resolver throwing exception
+Exception propagated: Resolver error
+
+Test 6: Circular external refs
+Circular refs handled: PASS
+
+Test 7: Clear resolver with null
+Cleared resolver handled: PASS
+
+All edge case tests completed!

--- a/tests/017-resolver-edge-cases.phpt
+++ b/tests/017-resolver-edge-cases.phpt
@@ -73,9 +73,16 @@ $validator->setRefResolver(function(string $uri, string $baseUri) use ($circular
     return $circularSchemas[$uri] ?? null;
 });
 $schema = ['$ref' => 'schema-a.json'];
-$data = ['b' => ['a' => ['b' => []]]];
+
+// Valid nested data should pass (use stdClass for empty objects)
+$data = ['b' => ['a' => ['b' => new stdClass()]]];
 $result = $validator->validate($data, $schema);
-echo "Circular refs handled: PASS\n";
+echo "Valid nested data: " . ($result ? "PASS" : "FAIL") . "\n";
+
+// Invalid data (wrong type) should fail
+$data = ['b' => 'not an object'];
+$result = $validator->validate($data, $schema);
+echo "Invalid type rejected: " . (!$result ? "PASS" : "FAIL") . "\n";
 
 // Test 7: Clear resolver with null
 echo "\nTest 7: Clear resolver with null\n";
@@ -103,7 +110,8 @@ Test 5: Resolver throwing exception
 Exception propagated: Resolver error
 
 Test 6: Circular external refs
-Circular refs handled: PASS
+Valid nested data: PASS
+Invalid type rejected: PASS
 
 Test 7: Clear resolver with null
 Cleared resolver handled: PASS

--- a/validator.c
+++ b/validator.c
@@ -1486,7 +1486,8 @@ static zval *resolve_json_pointer(zval *root, const char *pointer)
 
         /* Decode percent-encoding */
         while (*src) {
-            if (*src == '%' && isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
+            if (*src == '%' && src[1] != '\0' && src[2] != '\0' &&
+                isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
                 int high = (src[1] >= 'a') ? (src[1] - 'a' + 10) : ((src[1] >= 'A') ? (src[1] - 'A' + 10) : (src[1] - '0'));
                 int low = (src[2] >= 'a') ? (src[2] - 'a' + 10) : ((src[2] >= 'A') ? (src[2] - 'A' + 10) : (src[2] - '0'));
                 *dst++ = (char)((high << 4) | low);

--- a/validator.c
+++ b/validator.c
@@ -1455,6 +1455,96 @@ int json_schema_validate_if_then_else(zval *data, zval *if_schema, zval *then_sc
  * $ref Resolution
  * ========================================================================== */
 
+/*
+ * Resolve a JSON Pointer within a JSON value.
+ * pointer should be the part after "#/" (e.g., "definitions/Foo" for "#/definitions/Foo")
+ * Returns NULL if resolution fails.
+ */
+static zval *resolve_json_pointer(zval *root, const char *pointer)
+{
+    if (!root || !pointer) {
+        return NULL;
+    }
+
+    zval *current = root;
+    const char *ptr = pointer;
+
+    while (*ptr) {
+        const char *slash = strchr(ptr, '/');
+        size_t segment_len = slash ? (size_t)(slash - ptr) : strlen(ptr);
+
+        char segment[256];
+        if (segment_len >= sizeof(segment)) {
+            return NULL;
+        }
+        strncpy(segment, ptr, segment_len);
+        segment[segment_len] = '\0';
+
+        /* Decode percent-encoding first, then JSON Pointer escapes */
+        char *src = segment;
+        char *dst = segment;
+
+        /* Decode percent-encoding */
+        while (*src) {
+            if (*src == '%' && isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
+                int high = (src[1] >= 'a') ? (src[1] - 'a' + 10) : ((src[1] >= 'A') ? (src[1] - 'A' + 10) : (src[1] - '0'));
+                int low = (src[2] >= 'a') ? (src[2] - 'a' + 10) : ((src[2] >= 'A') ? (src[2] - 'A' + 10) : (src[2] - '0'));
+                *dst++ = (char)((high << 4) | low);
+                src += 3;
+            } else {
+                *dst++ = *src++;
+            }
+        }
+        *dst = '\0';
+
+        /* Decode JSON Pointer escapes (~0 = ~, ~1 = /) */
+        src = segment;
+        dst = segment;
+        while (*src) {
+            if (*src == '~') {
+                if (src[1] == '0') {
+                    *dst++ = '~';
+                    src += 2;
+                } else if (src[1] == '1') {
+                    *dst++ = '/';
+                    src += 2;
+                } else {
+                    *dst++ = *src++;
+                }
+            } else {
+                *dst++ = *src++;
+            }
+        }
+        *dst = '\0';
+
+        if (Z_TYPE_P(current) == IS_ARRAY) {
+            zval *next = zend_hash_str_find(Z_ARRVAL_P(current), segment, strlen(segment));
+            if (!next) {
+                /* Try numeric index */
+                char *end;
+                zend_long idx = strtol(segment, &end, 10);
+                if (*end == '\0') {
+                    next = zend_hash_index_find(Z_ARRVAL_P(current), idx);
+                }
+            }
+            if (!next) {
+                return NULL;
+            }
+            current = next;
+        } else {
+            return NULL;
+        }
+
+        if (slash) {
+            ptr = slash + 1;
+        } else {
+            break;
+        }
+    }
+
+    return current;
+}
+
 zval *json_schema_resolve_ref(zend_string *ref, json_schema_context *ctx)
 {
     if (!ctx->root_schema) {
@@ -1473,84 +1563,7 @@ zval *json_schema_resolve_ref(zend_string *ref, json_schema_context *ctx)
             return NULL;
         }
 
-        /* Parse JSON Pointer */
-        zval *current = ctx->root_schema;
-        const char *ptr = ref_str + 2;
-
-        while (*ptr) {
-            const char *slash = strchr(ptr, '/');
-            size_t segment_len = slash ? (size_t)(slash - ptr) : strlen(ptr);
-
-            char segment[256];
-            if (segment_len >= sizeof(segment)) {
-                return NULL;
-            }
-            strncpy(segment, ptr, segment_len);
-            segment[segment_len] = '\0';
-
-            /* Decode percent-encoding first, then JSON Pointer escapes */
-            char *src = segment;
-            char *dst = segment;
-
-            /* Decode percent-encoding */
-            while (*src) {
-                if (*src == '%' && isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
-                    int high = (src[1] >= 'a') ? (src[1] - 'a' + 10) : ((src[1] >= 'A') ? (src[1] - 'A' + 10) : (src[1] - '0'));
-                    int low = (src[2] >= 'a') ? (src[2] - 'a' + 10) : ((src[2] >= 'A') ? (src[2] - 'A' + 10) : (src[2] - '0'));
-                    *dst++ = (char)((high << 4) | low);
-                    src += 3;
-                } else {
-                    *dst++ = *src++;
-                }
-            }
-            *dst = '\0';
-
-            /* Decode JSON Pointer escapes (~0 = ~, ~1 = /) */
-            src = segment;
-            dst = segment;
-            while (*src) {
-                if (*src == '~') {
-                    if (src[1] == '0') {
-                        *dst++ = '~';
-                        src += 2;
-                    } else if (src[1] == '1') {
-                        *dst++ = '/';
-                        src += 2;
-                    } else {
-                        *dst++ = *src++;
-                    }
-                } else {
-                    *dst++ = *src++;
-                }
-            }
-            *dst = '\0';
-
-            if (Z_TYPE_P(current) == IS_ARRAY) {
-                zval *next = zend_hash_str_find(Z_ARRVAL_P(current), segment, strlen(segment));
-                if (!next) {
-                    /* Try numeric index */
-                    char *end;
-                    zend_long idx = strtol(segment, &end, 10);
-                    if (*end == '\0') {
-                        next = zend_hash_index_find(Z_ARRVAL_P(current), idx);
-                    }
-                }
-                if (!next) {
-                    return NULL;
-                }
-                current = next;
-            } else {
-                return NULL;
-            }
-
-            if (slash) {
-                ptr = slash + 1;
-            } else {
-                break;
-            }
-        }
-
-        return current;
+        return resolve_json_pointer(ctx->root_schema, ref_str + 2);
     }
 
     /* External reference - use PHP callback resolver */
@@ -1629,66 +1642,7 @@ zval *json_schema_resolve_ref(zend_string *ref, json_schema_context *ctx)
             return NULL;
         }
 
-        /* Parse JSON Pointer within external schema */
-        zval *current = external_schema;
-        const char *ptr = fragment + 2;
-
-        while (*ptr) {
-            const char *slash = strchr(ptr, '/');
-            size_t segment_len = slash ? (size_t)(slash - ptr) : strlen(ptr);
-
-            char segment[256];
-            if (segment_len >= sizeof(segment)) {
-                return NULL;
-            }
-            strncpy(segment, ptr, segment_len);
-            segment[segment_len] = '\0';
-
-            /* Decode JSON Pointer escapes */
-            char *src = segment;
-            char *dst = segment;
-            while (*src) {
-                if (*src == '~') {
-                    if (src[1] == '0') {
-                        *dst++ = '~';
-                        src += 2;
-                    } else if (src[1] == '1') {
-                        *dst++ = '/';
-                        src += 2;
-                    } else {
-                        *dst++ = *src++;
-                    }
-                } else {
-                    *dst++ = *src++;
-                }
-            }
-            *dst = '\0';
-
-            if (Z_TYPE_P(current) == IS_ARRAY) {
-                zval *next = zend_hash_str_find(Z_ARRVAL_P(current), segment, strlen(segment));
-                if (!next) {
-                    char *end;
-                    zend_long idx = strtol(segment, &end, 10);
-                    if (*end == '\0') {
-                        next = zend_hash_index_find(Z_ARRVAL_P(current), idx);
-                    }
-                }
-                if (!next) {
-                    return NULL;
-                }
-                current = next;
-            } else {
-                return NULL;
-            }
-
-            if (slash) {
-                ptr = slash + 1;
-            } else {
-                break;
-            }
-        }
-
-        return current;
+        return resolve_json_pointer(external_schema, fragment + 2);
     }
 
     return external_schema;


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #11.

### Changes

1. **Extract `resolve_json_pointer()` helper function**
   - Eliminates code duplication between local ref resolution and external schema fragment resolution
   - Both cases now use the same function with consistent behavior

2. **Fix missing percent-decoding in external fragment resolution**
   - External fragment resolution was missing percent-encoding decoding
   - Now handled by the shared `resolve_json_pointer()` function

3. **Add comprehensive resolver edge case tests**
   - Resolver returning `null`
   - Resolver returning invalid non-array values (string, integer, boolean)
   - Resolver throwing exception
   - Circular external refs
   - Clearing resolver with `null`

## Test plan

- [x] All 17 PHPT tests pass
- [x] New edge case tests cover resolver error handling

Fixes #12

## Summary by Sourcery

ローカルおよび外部の `$ref` 処理間でロジックを共有するために JSON Pointer の解決処理をリファクタリングし、リゾルバのエッジケースに対するカバレッジを追加しました。

Enhancements:
- ローカルおよび外部の `$ref` フラグメント解決を統一・簡素化するため、パーセントデコードの挙動を含めた再利用可能な JSON Pointer リゾルバのヘルパーを抽出しました。

Tests:
- 外部 `$ref` リゾルバのエッジケース（null および不正な戻り値、例外スロー、循環参照、null によるリゾルバのクリア）をカバーする PHPT テストを追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor JSON Pointer resolution to share logic between local and external $ref handling and add coverage for resolver edge cases.

Enhancements:
- Extract a reusable JSON Pointer resolver helper to unify and simplify local and external $ref fragment resolution, including percent-decoding behavior.

Tests:
- Add PHPT tests covering external $ref resolver edge cases, including null and invalid return values, thrown exceptions, circular references, and clearing the resolver with null.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended external reference support to resolve relative paths against a base URI, enabling access to schemas under a base path such as /schemas/v1/.

* **Tests**
  * Added comprehensive test coverage for resolver edge cases, including null returns, invalid types, circular references, and exception handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->